### PR TITLE
feat(hooks): validar formato de commits con pre-push y commit-msg

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # CC3S2-PC4
+
+### Git Hooks
+
+Ejecuta el siguiente script para instalar los hooks en tu entorno local
+```bash
+bash setup-hooks.sh
+```
+Este script configura automáticamente dos hooks personalizados:
+
+- pre-commit: se ejecuta antes de que un commit se registre, para validar el formato del mensaje.
+
+- pre-push: se ejecuta antes de hacer un git push y revisa que todos los commits pendientes por subir cumplan con el formato.

--- a/hooks/commit-msg.sh
+++ b/hooks/commit-msg.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# commit-msg: valida que el mensaje del commit siga el formato de Conventional Commits antes de registrarlo localmente. Si no cumple, el commit se cancela.
+
+# guardar la ruta del archivo temporal donde git guarda el mensaje del commit actual
+commit_msg_file="$1"
+
+# leer el contenido del mensaje
+commit_msg=$(cat "$commit_msg_file")
+
+# expresión regular que define un mensaje válido
+# tipo(scope opcional): descripción
+pattern="^(feat|fix|chore|docs|refactor|test|style|perf|ci|build|revert)(\([^)]+\))?: .+"
+
+echo "DEBUG: commit_msg='$commit_msg'"
+# validar que el mensaje cumpla con el formato
+if ! echo "$commit_msg" | grep -Eq "$pattern"; then
+  echo "Formato de commit inválido"
+  echo "Usar el formato válido: tipo(scope opcional): descripción"
+  exit 1
+fi
+
+echo "Formato de commit válido"
+exit 0

--- a/hooks/commit-msg.sh
+++ b/hooks/commit-msg.sh
@@ -12,7 +12,6 @@ commit_msg=$(cat "$commit_msg_file")
 # tipo(scope opcional): descripción
 pattern="^(feat|fix|chore|docs|refactor|test|style|perf|ci|build|revert)(\([^)]+\))?: .+"
 
-echo "DEBUG: commit_msg='$commit_msg'"
 # validar que el mensaje cumpla con el formato
 if ! echo "$commit_msg" | grep -Eq "$pattern"; then
   echo "Formato de commit inválido"

--- a/hooks/commit-msg.sh
+++ b/hooks/commit-msg.sh
@@ -16,6 +16,7 @@ pattern="^(feat|fix|chore|docs|refactor|test|style|perf|ci|build|revert)(\([^)]+
 if ! echo "$commit_msg" | grep -Eq "$pattern"; then
   echo "Formato de commit inválido"
   echo "Usar el formato válido: tipo(scope opcional): descripción"
+  echo "Referencia: https://www.conventionalcommits.org/en/v1.0.0/"
   exit 1
 fi
 

--- a/hooks/pre-push.sh
+++ b/hooks/pre-push.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# pre-push: revisa que todos los commits pendientes por subir al remoto tengan un formato válido. Si encuentra errores, se impide el push.
+
+# obtener el nombre de la rama actual
+branch=$(git rev-parse --abbrev-ref HEAD)
+
+# obtener los mensajes de commits que aún no han sido enviados al remoto
+commits=$(git log origin/$branch..HEAD --pretty=format:"%s")
+
+# expresión regular que define un mensaje válido
+# tipo(scope opcional): descripción
+pattern="^(feat|fix|chore|docs|refactor|test|style|perf|ci|build|revert)(\([\w\-]+\))?: .+"
+
+# filtrar mensajes que no cumplen con el formato esperado
+invalids=$(echo "$commits" | grep -Ev "$pattern")
+
+# impedir el push si existen commits inválidos
+if [ -n "$invalids" ]; then
+  echo "Existen commits pendientes con formato inválido:"
+  echo "$invalids"
+  exit 1
+fi
+
+echo "Todos los commits pendientes tienen formato válido"
+exit 0

--- a/hooks/pre-push.sh
+++ b/hooks/pre-push.sh
@@ -19,6 +19,7 @@ invalids=$(echo "$commits" | grep -Ev "$pattern")
 if [ -n "$invalids" ]; then
   echo "Existen commits pendientes con formato inválido:"
   echo "$invalids"
+  echo "Referencia: https://www.conventionalcommits.org/en/v1.0.0/"
   exit 1
 fi
 

--- a/hooks/pre-push.sh
+++ b/hooks/pre-push.sh
@@ -10,7 +10,7 @@ commits=$(git log origin/$branch..HEAD --pretty=format:"%s")
 
 # expresión regular que define un mensaje válido
 # tipo(scope opcional): descripción
-pattern="^(feat|fix|chore|docs|refactor|test|style|perf|ci|build|revert)(\([\w\-]+\))?: .+"
+pattern="^(feat|fix|chore|docs|refactor|test|style|perf|ci|build|revert)(\([^)]+\))?: .+"
 
 # filtrar mensajes que no cumplen con el formato esperado
 invalids=$(echo "$commits" | grep -Ev "$pattern")

--- a/setup-hooks.sh
+++ b/setup-hooks.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# copiar el hook commit-msg y el hook pre-push al directorio de hooks de git
+cp hooks/commit-msg.sh .git/hooks/commit-msg
+cp hooks/pre-push.sh .git/hooks/pre-push
+
+# asignar permisos de ejecución a ambos hooks 
+chmod +x .git/hooks/commit-msg .git/hooks/pre-push


### PR DESCRIPTION
- Se implementaron los hooks `commit-msg` y `pre-push` para validar que los mensajes de commit sigan el estándar de Conventional Commits.
- Se creó el script `setup-hooks.sh` para facilitar la instalación local de los hooks.
- Se documentó su uso en el README del proyecto.