### PR TITLE
feat(tests): Agregar pruebas para scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ python changelog_generator.py [-d RUTA_REPOSITORIO] [-o ARCHIVO_SALIDA]
 #### Dependencias
 
 El script depende de la librería `GitPython` para analizar los repositorios sin depender de llamadas directas al comando Git.
-### Git Hooks
+
+## Git Hooks
 
 Ejecuta el siguiente script para instalar los hooks en tu entorno local
 ```bash
@@ -31,3 +32,38 @@ Este script configura automáticamente dos hooks personalizados:
 - pre-commit: se ejecuta antes de que un commit se registre, para validar el formato del mensaje.
 
 - pre-push: se ejecuta antes de hacer un git push y revisa que todos los commits pendientes por subir cumplan con el formato.
+
+## Tests
+
+Para ejecutar los tests de este repositorio, solo es necesario ejecutar `pytest` en la raíz del proyecto.
+
+### 1. `test_parse_commits`
+
+* **Tipo**: Unitario, parametrizado.
+* **Propósito**: Verifica el correcto parseo de mensajes de commit según la convención Conventional Commits.
+
+### 2. `test_get_commits`
+
+* **Tipo**: Integración con fixture `temp_git_repo_basic`
+* **Propósito**: Asegura que se obtienen correctamente los commits realizados después del último tag en el repositorio temporal.
+
+### 3. `test_repo_no_tags`
+
+* **Tipo**: Integración con fixture `temp_git_repo_no_tags`
+* **Propósito**: Verifica que se lanza un `ValueError` si el repositorio no tiene ningún tag.
+
+### 4. `test_repo_create_tag`
+
+* **Tipo**: Integración con fixture `temp_git_repo_no_tags`
+* **Propósito**: Comprueba que `crear_tag(...)` añade correctamente un nuevo tag al repositorio Git.
+
+### 5. `test_calcular_siguiente_version`
+
+* **Tipo**: Unitario, parametrizado por fixture
+* **Fixtures utilizados**: `commits_fix_only`, `commits_with_feat`, `commits_breaking_change`
+* **Propósito**: Valida que `calcular_siguiente_version(...)` produce la versión semántica correcta (patch, minor o major) en función de los tipos de commits.
+* **Casos cubiertos**:
+
+  * Solo fixes → incremento de parche.
+  * Fixes + feat → incremento menor.
+  * BREAKING CHANGE → incremento mayor.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,59 @@
+import pytest
+from git import Repo
+from pathlib import Path
+import tempfile
+
+@pytest.fixture
+def temp_git_repo_basic() -> dict:
+    """
+    Crea un repo Git temporal con un tag y commits, y devuelve su metadata para validación.
+    """
+
+    tmp_dir = Path(tempfile.mkdtemp())
+    repo = Repo.init(tmp_dir)
+    file = tmp_dir / "archivo.txt"
+
+    commits_info = []
+
+    # Commit 1
+    file.write_text("Inicial")
+    repo.index.add([str(file)])
+    commit1 = repo.index.commit("chore: inicial")
+    repo.create_tag("v1.0.0")
+
+    # Commit 2
+    file.write_text("Funcionalidad")
+    repo.index.add([str(file)])
+    commit2 = repo.index.commit("feat(api): nueva ruta")
+    commits_info.append({
+        "commit": commit2.hexsha,
+        "tipo": "feat",
+        "descripcion": "nueva ruta"
+    })
+
+    # Commit 3
+    file.write_text("Arreglo")
+    repo.index.add([str(file)])
+    commit3 = repo.index.commit("fix: corregir bug")
+    commits_info.append({
+        "commit": commit3.hexsha,
+        "tipo": "fix",
+        "descripcion": "corregir bug"
+    })
+
+    return {
+        "repo_path": tmp_dir,
+        "expected_commits": commits_info
+    }
+
+@pytest.fixture
+def temp_git_repo_no_tags(tmp_path) -> Path:
+    repo_path = tmp_path / "repo_sin_tags"
+    repo = Repo.init(repo_path)
+
+    file = repo_path / "README.md"
+    file.write_text("Sin tags")
+    repo.index.add([str(file)])
+    repo.index.commit("feat: repo sin tags")
+
+    return repo_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from git import Repo
 from pathlib import Path
 import tempfile
 
+
 @pytest.fixture
 def temp_git_repo_basic() -> dict:
     """
@@ -25,26 +26,20 @@ def temp_git_repo_basic() -> dict:
     file.write_text("Funcionalidad")
     repo.index.add([str(file)])
     commit2 = repo.index.commit("feat(api): nueva ruta")
-    commits_info.append({
-        "commit": commit2.hexsha,
-        "tipo": "feat",
-        "descripcion": "nueva ruta"
-    })
+    commits_info.append(
+        {"commit": commit2.hexsha, "tipo": "feat", "descripcion": "nueva ruta"}
+    )
 
     # Commit 3
     file.write_text("Arreglo")
     repo.index.add([str(file)])
     commit3 = repo.index.commit("fix: corregir bug")
-    commits_info.append({
-        "commit": commit3.hexsha,
-        "tipo": "fix",
-        "descripcion": "corregir bug"
-    })
+    commits_info.append(
+        {"commit": commit3.hexsha, "tipo": "fix", "descripcion": "corregir bug"}
+    )
 
-    return {
-        "repo_path": tmp_dir,
-        "expected_commits": commits_info
-    }
+    return {"repo_path": tmp_dir, "expected_commits": commits_info}
+
 
 @pytest.fixture
 def temp_git_repo_no_tags(tmp_path) -> Path:
@@ -57,3 +52,45 @@ def temp_git_repo_no_tags(tmp_path) -> Path:
     repo.index.commit("feat: repo sin tags")
 
     return repo_path
+
+
+# Tests para probar lógica de generación de tags
+@pytest.fixture
+def commits_fix_only():
+    return {
+        "commits": [
+            {"mensaje": {"tipo": "fix", "descripcion": "arreglar error 1"}},
+            {"mensaje": {"tipo": "fix", "descripcion": "arreglar error 2"}},
+        ],
+        "tag": "v1.2.3",
+        "esperado": "v1.2.4",
+    }
+
+
+@pytest.fixture
+def commits_with_feat():
+    return {
+        "commits": [
+            {"mensaje": {"tipo": "fix", "descripcion": "arreglar error"}},
+            {"mensaje": {"tipo": "feat", "descripcion": "agregar funcionalidad"}},
+        ],
+        "tag": "v1.2.3",
+        "esperado": "v1.3.0",
+    }
+
+
+@pytest.fixture
+def commits_breaking_change():
+    return {
+        "commits": [
+            {
+                "mensaje": {
+                    "tipo": "BREAKING CHANGE",
+                    "descripcion": "realizar cambio crítico",
+                }
+            },
+            {"mensaje": {"tipo": "feat", "descripcion": "agregar funcionalidad"}},
+        ],
+        "tag": "v1.2.3",
+        "esperado": "v2.0.0",
+    }

--- a/tests/test_changelog_generator.py
+++ b/tests/test_changelog_generator.py
@@ -1,0 +1,75 @@
+from scripts import changelog_generator as cg
+import pytest
+
+
+@pytest.mark.parametrize(
+    "mensaje, tipo, escopo, descripcion, cuerpo",
+    [
+        (
+            "feat(api): agregar caracteristica\n\nAgregar caracteristica importante.",
+            "feat",
+            "api",
+            "agregar caracteristica",
+            "Agregar caracteristica importante.",
+        ),
+        (
+            "fix: arreglar error\n\nArreglar error fatal.",
+            "fix",
+            None,
+            "arreglar error",
+            "Arreglar error fatal.",
+        ),
+        ("commit inicial", "otro", None, "commit inicial", None),
+        (
+            "feat(api): agregar caracteristica\n\n\n\n\n",
+            "feat",
+            "api",
+            "agregar caracteristica",
+            None,
+        ),
+        (
+            "feat!(break): agregar caracteristica\n\nAgregar caracteristica importante.",
+            "BREAKING CHANGE",
+            "break",
+            "agregar caracteristica",
+            "Agregar caracteristica importante."
+        )
+    ],
+)
+
+def test_parse_commits(mensaje, tipo, escopo, descripcion, cuerpo):
+    """
+    Probar funcionalidad de parseo de commits.
+    Asegurar que regex y construcción de diccionario se cumplan.
+    """
+    result = cg.parse_commit_message(mensaje, "abc123")
+    assert result["commit"] == "abc123"
+    assert result["mensaje"]["tipo"] == tipo
+    assert result["mensaje"]["escopo"] == escopo
+    assert result["mensaje"]["descripcion"] == descripcion
+    assert result["mensaje"]["cuerpo"] == cuerpo
+
+
+def test_get_commits(temp_git_repo_basic):
+    """
+    Probar funcionalidad de obtención de commits en repositorio.
+    """
+    repo_path = temp_git_repo["repo_path"]
+    expected = temp_git_repo["expected_commits"]
+
+    commits = cg.get_commits_since_last_tag(str(repo_path))
+
+    assert len(commits) == len(expected)
+
+    actual = {(c["commit"], c["mensaje"]["tipo"], c["mensaje"]["descripcion"]) for c in commits}
+    esperado = {(e["commit"], e["tipo"], e["descripcion"]) for e in expected}
+
+    assert actual == esperado
+
+def test_repo_no_tags(temp_git_repo_no_tags):
+    """
+    Probar que se lance error cuando no se encuentran tags en el repositorio.
+    """
+    repo_path = temp_git_repo_no_tags
+    with pytest.raises(ValueError, match="tags"):
+        commits = cg.get_commits_since_last_tag(str(repo_path))

--- a/tests/test_changelog_generator.py
+++ b/tests/test_changelog_generator.py
@@ -1,4 +1,5 @@
 from scripts import changelog_generator as cg
+from git import Repo
 import pytest
 
 
@@ -32,11 +33,10 @@ import pytest
             "BREAKING CHANGE",
             "break",
             "agregar caracteristica",
-            "Agregar caracteristica importante."
-        )
+            "Agregar caracteristica importante.",
+        ),
     ],
 )
-
 def test_parse_commits(mensaje, tipo, escopo, descripcion, cuerpo):
     """
     Probar funcionalidad de parseo de commits.
@@ -54,17 +54,21 @@ def test_get_commits(temp_git_repo_basic):
     """
     Probar funcionalidad de obtención de commits en repositorio.
     """
-    repo_path = temp_git_repo["repo_path"]
-    expected = temp_git_repo["expected_commits"]
+    repo_path = temp_git_repo_basic["repo_path"]
+    expected = temp_git_repo_basic["expected_commits"]
 
     commits = cg.get_commits_since_last_tag(str(repo_path))
 
     assert len(commits) == len(expected)
 
-    actual = {(c["commit"], c["mensaje"]["tipo"], c["mensaje"]["descripcion"]) for c in commits}
+    actual = {
+        (c["commit"], c["mensaje"]["tipo"], c["mensaje"]["descripcion"])
+        for c in commits
+    }
     esperado = {(e["commit"], e["tipo"], e["descripcion"]) for e in expected}
 
     assert actual == esperado
+
 
 def test_repo_no_tags(temp_git_repo_no_tags):
     """
@@ -73,3 +77,33 @@ def test_repo_no_tags(temp_git_repo_no_tags):
     repo_path = temp_git_repo_no_tags
     with pytest.raises(ValueError, match="tags"):
         commits = cg.get_commits_since_last_tag(str(repo_path))
+
+def test_repo_create_tag(temp_git_repo_no_tags):
+    """
+    Probar creación de tag de crear_tag en un repositorio.
+    """
+    repo_path = temp_git_repo_no_tags
+    created_tag = "v1.0.0"
+    cg.crear_tag(repo_path, created_tag)
+    repo_tags = sorted(Repo(repo_path).tags, key=lambda t: t.commit.committed_datetime)
+    assert repo_tags[-1].name == created_tag
+
+# Utiliza los fixtures de conftest.py
+# No se necesita probar toda la lógica de parseo de commits, por lo que crear
+# un repositorio temporal no es necesario.
+@pytest.mark.parametrize(
+    "version_commits", ["commits_fix_only", "commits_with_feat", "commits_breaking_change"]
+)
+def test_calcular_siguiente_version(request, version_commits):
+    """
+    Probar funcionalidad de calculo de version siguiente.
+    """
+    datos = request.getfixturevalue(version_commits)
+    commits = datos["commits"]
+    tag = datos["tag"]
+    esperado = datos["esperado"]
+
+    resultado = cg.calcular_siguiente_version(commits, tag)
+    assert (
+        resultado == esperado
+    ), f"{version_commits} esperado {esperado}, obtenido {resultado}"


### PR DESCRIPTION
- Agregar tests con `pytest` para `changelog_generator.py`. Se utilizan fixtures para crear repositorios temporales y mensajes de commit simples.
- Agregar documentación de tests en README.md