### PR TITLE
feat(release-flow): agregar script bash para orquestar flujo de liberación local

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,18 @@
 Se usó un repositorio aparte para probar este proyecto, se añadió ese repositorio como el submódulo "aux-repo".
 
 ## Scripts
+### `release_flow.sh`
+Script principal que orquesta el flujo de liberación local del proyecto. Ejecuta automáticamente el changelog_generator.py, muestra una vista previa del archivo CHANGELOG.md, detecta la nueva versión generada y permite al usuario confirmar si desea crear (o reetiquetar) y pushear el tag correspondiente al repositorio remoto.
+
+#### Uso
+
+```bash
+bash release_flow.sh
+```
 
 ### `changelog_generator.py`
 
-Script principal para parsear commits de un repositorio Git. Se priorizan los commits convencionales, considerando cualquier otro commit en la categoría "otro". La salida es almacenada como un archivo JSON con los commits ordenados desde el más antiguo al más reciente. Además, el script genera automáticamente un archivo CHANGELOG.md con los commits agrupados por tipo (feat, fix, etc.), calcula la siguiente versión siguiendo el versionado semántico (MAJOR.MINOR.PATCH) según los cambios detectados desde el último tag y crea un nuevo tag Git local con la versión correspondiente.
+Script para parsear commits de un repositorio Git. Se priorizan los commits convencionales, considerando cualquier otro commit en la categoría "otro". La salida es almacenada como un archivo JSON con los commits ordenados desde el más antiguo al más reciente. Además, el script genera automáticamente un archivo CHANGELOG.md con los commits agrupados por tipo (feat, fix, etc.), calcula la siguiente versión siguiendo el versionado semántico (MAJOR.MINOR.PATCH) según los cambios detectados desde el último tag y crea un nuevo tag Git local con la versión correspondiente.
 También se calculan métricas de flujo usando los commits como referencia para saber el flujo de trabajo del equipo. Estas métricas son dos, throughput, que se calcula como el número de commits promedio por día, y task distribution, que es la proporción por cada tipo de trabajo o tarea realizada. Estos resultados son guardados en un documento metrics.json.
 
 #### Uso

--- a/release_flow.sh
+++ b/release_flow.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+# release_flow.sh
+# Flujo de liberación local: changelog + versión + creación de tag + push
+
+set -e  
+
+REPO_DIR="."
+SCRIPT="scripts/changelog_generator.py"
+
+echo "Generando CHANGELOG y calculando la siguiente versión del proyecto"
+output=$(python "$SCRIPT" -d "$REPO_DIR") || {
+    echo "Error al ejecutar $SCRIPT"
+    exit 1
+}
+
+# Extraer la versión generada
+version=$(echo "$output" | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+' | tail -1)
+
+if [[ -z "$version" ]]; then
+    echo "No se detectó una versión válida desde el script"
+    exit 1
+fi
+
+# Validar que CHANGELOG.md existe
+if [[ ! -f "CHANGELOG.md" ]]; then
+    echo "No se encontró el archivo CHANGELOG.md"
+    exit 1
+fi
+
+# Verificar si hay commits nuevos
+if echo "$output" | grep -q "No se encontraron commits nuevos"; then
+    echo "No hay commits nuevos desde el último tag. No se generará changelog ni se actualizará el tag."
+    exit 0
+fi
+
+# Verificar si la nueva versión es igual al último tag
+ultimo_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+if [[ "$version" == "$ultimo_tag" ]]; then
+    echo "Se detectaron nuevos commits, pero no afectan la versión semántica ($version)"
+    read -p "¿Deseas reetiquetar '$version' al nuevo commit? [y/N]: " retag
+    if [[ "$retag" =~ ^[Yy]$ ]]; then
+        git tag -d "$version"
+        git tag "$version"
+        echo "Tag '$version' actualizado localmente para apuntar al último commit."
+
+        if git ls-remote --tags origin | grep -q "refs/tags/$version"; then
+            read -p "El tag ya existe en remoto. ¿Deseas forzar el push? [y/N]: " force_push
+            if [[ "$force_push" =~ ^[Yy]$ ]]; then
+                git push --force origin "$version"
+                echo "Tag actualizado y forzado en remoto."
+            else
+                echo "Push cancelado por el usuario."
+            fi
+        else
+            git push origin "$version"
+            echo "Tag nuevo enviado al remoto."
+        fi
+    else
+        echo "Tag no actualizado."
+    fi
+    exit 0
+fi
+
+echo ""
+echo "Vista previa del nuevo CHANGELOG.md:"
+echo "----------------------------------------"
+tail -n 20 CHANGELOG.md
+echo "----------------------------------------"
+echo ""
+echo "Versión sugerida por el script: $version"
+echo ""
+
+# Confirmación del usuario
+read -p "¿Deseas continuar y pushear el tag '$version'? [y/N]: " confirm
+if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
+    echo "Operación cancelada por el usuario."
+    exit 0
+fi
+
+# Verificar si el tag existe localmente
+if git rev-parse "$version" >/dev/null 2>&1; then
+    echo "El tag '$version' existe localmente."
+else
+    echo "El tag '$version' no existe localmente. Verifica si fue creado correctamente por el script."
+    exit 1
+fi
+
+# Verificar si ya está en el remoto
+if git ls-remote --tags origin | grep -q "refs/tags/$version"; then
+    echo "El tag '$version' ya existe en el repositorio remoto."
+    read -p "¿Deseas forzar el push del tag local para que apunte al último commit? [y/N]: " force_push
+    if [[ "$force_push" != "y" && "$force_push" != "Y" ]]; then
+        echo "Push cancelado por el usuario."
+        exit 0
+    fi
+    git push --force origin "$version"
+else
+    git push origin "$version"
+fi
+
+echo "Tag '$version' enviado al repositorio remoto exitosamente."
+
+exit 0

--- a/release_flow.sh
+++ b/release_flow.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
-# release_flow.sh
-# Flujo de liberación local: changelog + versión + creación de tag + push
+# release_flow.sh - Script para orquestar un flujo de liberación local
+# Autor: Ariana Camila Lopez Julcarima - aclj20
 
 set -e  
 
+# Ruta al repositorio y script principal
 REPO_DIR="."
 SCRIPT="scripts/changelog_generator.py"
 
+# Ejecutar el script Python para generar el changelog y la versión
 echo "Generando CHANGELOG y calculando la siguiente versión del proyecto"
 output=$(python "$SCRIPT" -d "$REPO_DIR") || {
     echo "Error al ejecutar $SCRIPT"
@@ -17,12 +19,13 @@ output=$(python "$SCRIPT" -d "$REPO_DIR") || {
 # Extraer la versión generada
 version=$(echo "$output" | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+' | tail -1)
 
+# Verificar si se obtuvo una versión válida
 if [[ -z "$version" ]]; then
     echo "No se detectó una versión válida desde el script"
     exit 1
 fi
 
-# Validar que CHANGELOG.md existe
+# Validar que CHANGELOG.md fue generado
 if [[ ! -f "CHANGELOG.md" ]]; then
     echo "No se encontró el archivo CHANGELOG.md"
     exit 1
@@ -34,16 +37,20 @@ if echo "$output" | grep -q "No se encontraron commits nuevos"; then
     exit 0
 fi
 
-# Verificar si la nueva versión es igual al último tag
+# Obtener el último tag del repositorio
 ultimo_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+# Si la nueva versión es igual al último tag, permitir reetiquetar
 if [[ "$version" == "$ultimo_tag" ]]; then
     echo "Se detectaron nuevos commits, pero no afectan la versión semántica ($version)"
     read -p "¿Deseas reetiquetar '$version' al nuevo commit? [y/N]: " retag
     if [[ "$retag" =~ ^[Yy]$ ]]; then
+        # Reemplazar el tag local por uno apuntando al nuevo commit
         git tag -d "$version"
         git tag "$version"
         echo "Tag '$version' actualizado localmente para apuntar al último commit."
 
+        # Verificar si el tag ya existe en el remoto
         if git ls-remote --tags origin | grep -q "refs/tags/$version"; then
             read -p "El tag ya existe en remoto. ¿Deseas forzar el push? [y/N]: " force_push
             if [[ "$force_push" =~ ^[Yy]$ ]]; then
@@ -62,6 +69,7 @@ if [[ "$version" == "$ultimo_tag" ]]; then
     exit 0
 fi
 
+# Mostrar vista previa del changelog generado
 echo ""
 echo "Vista previa del nuevo CHANGELOG.md:"
 echo "----------------------------------------"
@@ -71,7 +79,7 @@ echo ""
 echo "Versión sugerida por el script: $version"
 echo ""
 
-# Confirmación del usuario
+# Confirmar si se desea hacer push del tag
 read -p "¿Deseas continuar y pushear el tag '$version'? [y/N]: " confirm
 if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
     echo "Operación cancelada por el usuario."
@@ -86,7 +94,7 @@ else
     exit 1
 fi
 
-# Verificar si ya está en el remoto
+# Verificar si el tag existe en el remoto
 if git ls-remote --tags origin | grep -q "refs/tags/$version"; then
     echo "El tag '$version' ya existe en el repositorio remoto."
     read -p "¿Deseas forzar el push del tag local para que apunte al último commit? [y/N]: " force_push

--- a/scripts/changelog_generator.py
+++ b/scripts/changelog_generator.py
@@ -21,6 +21,7 @@ Requiere:
 Autor:
     Diego Akira García Rojas - Akira-13
     Sandro Alfredo Carrillo Jordán - SandroCJ210
+    Ariana Camila Lopez Julcarima - aclj20
 """
 
 import json
@@ -106,6 +107,7 @@ def get_commits_since_last_tag(repo_path=".") -> List[Dict]:
     print(f"Se encontraron {len(commits)} commits desde el último tag: {last_tag}")
     parsed_commits = []
 
+    # Si no hay commits nuevos, se detiene el flujo de generación de changelog y tag
     if not commits:
         print(f"No hay commits nuevos desde el último tag ({last_tag}).")
         return parsed_commits


### PR DESCRIPTION
- Implementé el script `release_flow.sh` para automatizar el flujo de liberación local. El script genera el CHANGELOG, calcula la siguiente versión semántica y permite hacer push del tag al remoto.
- Corregí el script `changelog_generator.py` para que maneje correctamente el caso en el que no hay commits nuevos desde el último tag.
