### PR TITLE
[C2] Agregar tests de integración

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,29 @@ Para ejecutar los tests de este repositorio, solo es necesario ejecutar `pytest`
   * Solo fixes → incremento de parche.
   * Fixes + feat → incremento menor.
   * BREAKING CHANGE → incremento mayor.
+
+### 6. `test_generar_changelog_md`
+
+* **Tipo**: Unitario, parametrizado con fixture.
+* **Propósito**: Verifica que la función `generar_changelog_md(...)` cree correctamente un archivo `CHANGELOG.md` estructurado y con contenido esperable.
+* **Fixture usado**: `changelog_commits`, que define:
+
+  * una lista de commits parseados,
+  * la versión del release simulada,
+  * y una estructura esperada de secciones con sus entradas.
+
+### 7. `test_release_flow`
+
+* **Tipo**: Integración.
+* **Propósito**: Simula el flujo completo de una liberación:
+
+  1. Obtiene los commits desde el último tag.
+  2. Calcula la nueva versión semántica con base en los tipos de commit.
+  3. Genera un archivo `CHANGELOG.md` con el contenido agrupado.
+  4. Crea un nuevo tag Git con la versión calculada.
+* **Fixture usado**: `temp_git_repo`, que proporciona:
+
+  * el repositorio Git temporal,
+  * los commits esperados,
+  * el contenido esperado del changelog,
+  * la versión esperada (`expected_version`).


### PR DESCRIPTION
- Agregar tests de integración que simulen un flujo de libearción.
- Agregar documentación de los nuevos tests realizados.
- Refinar los fixtures para que tengan más alcance como repositorios temporales.