### PR TITLE
feat: agregar validaciones al script validate_release.sh

### DIFF
--- a/validate_release.sh
+++ b/validate_release.sh
@@ -5,10 +5,6 @@ set -e
 
 #Seguridad
 
-current_branch=$(git rev-parse --abbrev-ref HEAD)
-if [[ "$current_branch" != "main" ]]; then
-    echo "Se debe ejecutar el release desde la rama 'main'. Rama actual: $current_branch"
-fi
 # Detectar archivos sensibles
 sensitive_files=$(find . -type f \( -name ".env" -o -name ".key" -o -name "secrets.*" \))
 if [[ -n "$sensitive_files" ]]; then
@@ -27,21 +23,23 @@ bandit scripts/changelog_generator.py || echo "Errores detectados con bandit"
 shellcheck release_flow.sh || echo "Errores detectados con shellcheck"
 
 #Compliance
-# Validar formato del último commit
+
+#Validar formato del último commit
 last_msg=$(git log -1 --pretty=format:"%s")
 pattern="^(feat|fix|chore|docs|refactor|test|style|perf|ci|build|revert)(!)?(\([^)]+\))?: .+"
+
 if ! [[ "$last_msg" =~ $pattern ]]; then
-    echo "El último commit no sigue el formato convencional:"
+    echo "El último commit no cumple con el formato convencional"
     echo "$last_msg"
 fi
 
-# Validar existencia de CHANGELOG.md
+#Validar existencia de CHANGELOG.md
 if [[ ! -f "CHANGELOG.md" ]]; then
     echo "No se encontró el archivo CHANGELOG.md"
 fi
 
-# Verificar que el último tag es semántico
-last_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+#Verificar que el último tag es semántico
+last_tag= $(git describe --tags --abbrev=0 2>/dev/null || echo "")
 if [[ ! "$last_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "El último tag '$last_tag' no cumple con el formato semántico (vX.Y.Z)"
+    echo "El último tag $last_tag no cumple con el formato semántico (vX.Y.Z)"
 fi


### PR DESCRIPTION
Agregue nuevas validaciones correspondientes a Compliance.
- Verifique que el último commit siga el formato convencional
- Verifique que exista el archivo CHANGELOG.md
- Verifique que el último tag siga el formato de versionado semántico

Anteriormente había agregado validaciones de seguridad y linting