### PR TITLE
feat: agregar validación de seguridad y linting para repositorios host y auxiliar

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-ignore=E501,E302,W293,W291,W292,F401,F541,E305,E265
+ignore=E501
 max-line-length=120

--- a/validate_aux_repo.sh
+++ b/validate_aux_repo.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+#Detener ante cualquier error
+set -e
+
+#Validar formato del último commit
+last_msg=$(git log -1 --pretty=format:"%s")
+pattern="^(feat|fix|chore|docs|refactor|test|style|perf|ci|build|revert)(!)?(\([^)]+\))?: .+"
+
+if ! [[ "$last_msg" =~ $pattern ]]; then
+    echo "El último commit no cumple con el formato convencional"
+    echo "$last_msg"
+    echo 1
+fi
+echo "El último commit cumple con el formato"
+
+#Validar existencia de CHANGELOG.md
+if [[ ! -f "CHANGELOG.md" ]]; then
+    echo "No se encontró el archivo CHANGELOG.md"
+    exit 1
+fi
+echo "Archivo CHANGELOG.md encotrado"
+
+#Verificar que el último tag es semántico
+last_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "none")
+if [[ ! "$last_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "El último tag $last_tag no cumple con el formato semántico (vX.Y.Z)"
+    exit 1
+fi
+echo "Tag semántico válido"

--- a/validate_host_repo.sh
+++ b/validate_host_repo.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+#Detener ante cualquier error
+set -e
+
+#Seguridad
+
+# Detectar archivos sensibles
+sensitive_files=$(find . -type f \( -name ".env" -o -name ".key" -o -name "secrets.*" \))
+if [[ -n "$sensitive_files" ]]; then
+    echo "Se encontraron archivos sensibles:"
+    echo "$sensitive_files"
+fi
+echo "Sin archivos sensibles detectados"
+
+# Linting
+
+#Ejecutar flake8
+flake8 scripts/changelog_generator.py || {
+    echo "Errores detectados con flake8"
+    exit 1
+}
+echo "flake8 sin errores"
+
+# Ejecutar Bandit
+bandit scripts/changelog_generator.py > /dev/null 2>&1|| {
+    echo "Errores detectados con bandit"
+    exit 1
+}
+echo "bandit sin errores"
+
+# Ejecutar shellcheck 
+shellcheck release_flow.sh || {
+    echo "Errores detectados con shellcheck"
+    exit 1
+}
+echo "shellcheck sin errores"
+
+echo "Validación exitosa"
+

--- a/validate_release.sh
+++ b/validate_release.sh
@@ -5,10 +5,6 @@ set -e
 
 #Seguridad
 
-current_branch=$(git rev-parse --abbrev-ref HEAD)
-if [[ "$current_branch" != "main" ]]; then
-    echo "Se debe ejecutar el release desde la rama 'main'. Rama actual: $current_branch"
-fi
 # Detectar archivos sensibles
 sensitive_files=$(find . -type f \( -name ".env" -o -name ".key" -o -name "secrets.*" \))
 if [[ -n "$sensitive_files" ]]; then
@@ -27,21 +23,23 @@ bandit scripts/changelog_generator.py || echo "Errores detectados con bandit"
 shellcheck release_flow.sh || echo "Errores detectados con shellcheck"
 
 #Compliance
-# Validar formato del último commit
+
+#Validar formato del último commit
 last_msg=$(git log -1 --pretty=format:"%s")
 pattern="^(feat|fix|chore|docs|refactor|test|style|perf|ci|build|revert)(!)?(\([^)]+\))?: .+"
+
 if ! [[ "$last_msg" =~ $pattern ]]; then
-    echo "El último commit no sigue el formato convencional:"
+    echo "El último commit no cumple con el formato convencional"
     echo "$last_msg"
 fi
 
-# Validar existencia de CHANGELOG.md
+#Validar existencia de CHANGELOG.md
 if [[ ! -f "CHANGELOG.md" ]]; then
     echo "No se encontró el archivo CHANGELOG.md"
 fi
 
-# Verificar que el último tag es semántico
-last_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+#Verificar que el último tag es semántico
+last_tag= $(git describe --tags --abbrev=0 2>/dev/null || echo "")
 if [[ ! "$last_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "El último tag '$last_tag' no cumple con el formato semántico (vX.Y.Z)"
+    echo "El último tag $last_tag no cumple con el formato semántico (vX.Y.Z)"
 fi


### PR DESCRIPTION
Este PR incorpora dos nuevos scripts de validación:
- validate_host_repo.sh: realiza validaciones de linting con flake8, bandit y shellcheck sobre los scripts principales.
- validate_aux_repo.sh: verifica el cumplimiento de convenciones  de commits y versionado semántico de tags