### PR TITLE
build: agregar ejecución de validate_release en y validate_aux_repo.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,6 @@ jobs:
 
       - name: Clonar repositorio auxiliar
         run: git clone https://github.com/SandroCJ210/Aux-Repo-PC4 repo-auxiliar
-      
-      - name: Debuggear repositorio auxiliar
-        run: |
-          ls
 
       - name: Instalar dependencias en el repositorio actual
         run: |
@@ -46,7 +42,7 @@ jobs:
         working-directory: repo-auxiliar
         run: |
           bash validate_aux_repo.sh
-          
+
       - name: Configurar Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,16 @@ jobs:
       - name: Ejecutar pruebas unitarias
         run: |
           pytest tests/
+      
+      - name: Validación de seguridad
+        run: |
+          bash validate_release.sh
 
+      - name: Ejecutar validación en el repositorio auxiliar
+        working-directory: repo-auxiliar
+        run: |
+          bash validate_aux_repo.sh
+          
       - name: Configurar Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
En este PR se realiza lo siguiente:
- Se ejecuta el archivo validate_release.sh.
- Se ejecuta el archivo validate_aux_repo.sh en el repositorio auxiliar.